### PR TITLE
Add before Functionality to the Switch System

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ local authSwitch = Switch("auth")
 print(authSwitch:execute("login"))  -- "Logging in..."
 ```
 
+### Before Execution Checks
+```lua
+local secureSwitch = Switch("secure")
+    :before(function(action)
+        local allowedActions = { start = true, stop = true }
+        return allowedActions[action] ~= nil
+    end)
+    :when("start", function()
+        return "Starting secure process..."
+    end)
+    :when("stop", function()
+        return "Stopping secure process..."
+    end)
+
+print(secureSwitch:execute("start")) -- "Starting secure process..."
+print(secureSwitch:execute("invalid")) -- nil, before check fails
+```
+
+
 ### Events (Debug/Logging)
 ```lua
 local debugSwitch = Switch("debug")

--- a/examples/_switch_complex_example.lua
+++ b/examples/_switch_complex_example.lua
@@ -24,6 +24,12 @@ local gameSwitch = Switch("game", { maxCases = 50 })
         print("Middleware 2: Collecting stats:", value)
         return value
     end)
+    -- Before
+    :before(function(value)
+        print("Before check for value:", value)
+        local allowedActions = { start = true, pause = true, resume = true, quit = true }
+        return allowedActions[value] ~= nil
+    end)
     -- Game actions
     :when("start", function()
         return "Game started"

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,16 +1,16 @@
 --[[
     EasySwitchLua
     An advanced and efficient switch system for Lua
-
+    
     Usage:
     local Switch = require("easyswitch")
-
+    
     local menuSwitch = Switch("menu")
-        :when("start", function()
-            return "Game started"
+        :when("start", function() 
+            return "Game started" 
         end)
-        :when("quit", function()
-            return "Game ended"
+        :when("quit", function() 
+            return "Game ended" 
         end)
 
     print(menuSwitch:execute("start"))
@@ -23,80 +23,93 @@ local CacheManager = require("src.cacheManager")
 
 local function Switch(name, options)
     options = options or {}
-
-    -- Manager initialization
+    
+    -- Initialize managers
     local eventManager = EventManager.new()
     local middlewareManager = MiddlewareManager.new(eventManager)
     local actionManager = ActionManager.new(options.maxCases)
     local cacheManager = CacheManager.new(eventManager)
-
-    -- Constructing the switch
+    
+    -- Build the switch
     local switch = {}
+    
+    local beforeCheck = function() return true end
 
     -- API Events
     function switch:on(event, callback)
         eventManager.on(event, callback)
         return self
     end
-
+    
     -- API Actions
     function switch:when(cases, action)
         actionManager.add(cases, action)
         return self
     end
-
+    
     function switch:default(action)
         actionManager.setDefault(action)
         return self
     end
-
+    
     -- API Middleware
     function switch:use(middleware)
         middlewareManager.add(middleware)
         return self
     end
 
+    -- API Before
+    function switch:before(checkFunction)
+        beforeCheck = checkFunction or beforeCheck
+        return self
+    end
+    
     -- Execution
     function switch:execute(value)
         eventManager.emit("beforeExecute", value)
-
-        -- Check cache
+        
+        -- Cache check
         local cached = cacheManager.get(value)
         if cached ~= nil then
             eventManager.emit("afterExecute", value, cached)
             return cached
         end
+        
+        if not beforeCheck(value) then
+            eventManager.emit("beforeCheckFailed", value)
+            return nil
+        end
 
-        -- Apply middlewares
+        -- Apply middleware
         local final_value = middlewareManager.execute(value)
-
-        -- Execute action
+        
+        -- Execute the action
         local success, result = pcall(actionManager.execute, final_value)
         if not success then
             eventManager.emit("error", "action", result)
             result = nil
         end
-
-        -- Cache and return result
+        
+        -- Cache and return
         if result ~= nil then
             cacheManager.set(value, result)
         end
-
+        
         eventManager.emit("afterExecute", value, result)
         return result
     end
-
+    
     -- Utility methods
     function switch:clearCache()
         cacheManager.clear()
         return self
     end
-
+    
     function switch:clearEvents(event)
         eventManager.clear(event)
         return self
     end
-
+    
     return switch
 end
 


### PR DESCRIPTION
This pull request introduces a new before functionality to the advanced switch system for Lua. The before method allows you to define a pre-execution check function that runs before the action associated with a given case is executed. If the check function fails (returns false), the action execution is canceled, and a beforeCheckFailed event is emitted.

Key Changes:

 - Added the before(checkFunction) method to the Switch constructor.
 -  The beforeCheck function is invoked in the execute method before applying middlewares and executing the action.
 -  Emission of a beforeCheckFailed event if the check fails.
 -  Updated inline documentation to reflect the addition of this new feature.
 -  This enhancement provides greater flexibility and additional control over the execution of actions within the switch system.